### PR TITLE
Fix Osx libtoolize

### DIFF
--- a/check_tools.sh
+++ b/check_tools.sh
@@ -18,7 +18,12 @@ check_installed() {
 for prog in automake autoconf pkg-config java ant yasm nasm wget; do
 	check_installed "$prog" "it"
 done
-check_installed "libtoolize" "libtool"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then #OSX
+	check_installed "libtool" "libtool"
+else
+	check_installed "libtoolize" "libtool"
+fi
 check_installed "ndk-build" "android NDK"
 if check_installed "android" "android SDK"; then
 	check_installed "adb" "android SDK platform tools"


### PR DESCRIPTION
Hello guys, and thanks for your work
But libtoolize doesn't exist on OSX, that's why I updated the `check_tool` script