### PR TITLE
Dynamic photo URI loading for incoming calls

### DIFF
--- a/res/layout/call_incoming.xml
+++ b/res/layout/call_incoming.xml
@@ -74,6 +74,7 @@
 				android:adjustViewBounds="true"/>
 
 			<ImageView
+				android:id="@+id/avatar_mask_border"
 				android:src="@drawable/avatar_mask_border"
 				android:layout_width="200dp"
 				android:layout_height="wrap_content"

--- a/res/values/non_localizable_strings.xml
+++ b/res/values/non_localizable_strings.xml
@@ -130,6 +130,7 @@
 	<string name="pref_rfc2833_dtmf_key">pref_rfc2833_dtmf_key</string>
 	<string name="pref_sipinfo_dtmf_key">pref_sipinfo_dtmf_key</string>
 	<string name="pref_voice_mail_key">pref_voice_mail_key</string>
+	<string name="pref_dynamic_photo_uri_key">pref_dynamic_photo_uri_key</string>
 	<string name="pref_upnp_enable_key">pref_upnp_enable_key</string>
 
 	<string name="pref_first_time_linphone_chat_storage">pref_first_time_linphone_chat_storage</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -277,6 +277,7 @@
 	<string name="pref_rfc2833_dtmf">Send RFC2833 DTMFs</string>
 	<string name="pref_sipinfo_dtmf">Send SIP INFO DTMFs</string>
 	<string name="pref_voice_mail">Voice mail URI</string>
+	<string name="pref_dynamic_photo_uri">Dynamic Photo URI</string>
 	
 	<!-- Chat settings -->
 	<string name="pref_chat_title">Chat</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -215,6 +215,11 @@
 				    android:title="@string/pref_voice_mail"
 					android:key="@string/pref_voice_mail_key"
 					android:persistent="false"/>
+	
+				<EditTextPreference
+				    android:title="@string/pref_dynamic_photo_uri"
+					android:key="@string/pref_dynamic_photo_uri_key"
+					android:persistent="false"/>
 				
 			</PreferenceCategory>
 

--- a/src/org/linphone/LinphonePreferences.java
+++ b/src/org/linphone/LinphonePreferences.java
@@ -899,6 +899,14 @@ public class LinphonePreferences {
 	public void setVoiceMailUri(String uri) {
 		getConfig().setString("app", "voice_mail", uri);
 	}
+
+	public String getDynamicPhotoUri() {
+		return getConfig().getString("app", "dynamic_photo_uri", null);
+	}
+
+	public void setDynamicPhotoUri(String uri) {
+		getConfig().setString("app", "dynamic_photo_uri", uri);
+	}
 	// End of call settings
 
 	// Network settings

--- a/src/org/linphone/SettingsFragment.java
+++ b/src/org/linphone/SettingsFragment.java
@@ -885,6 +885,7 @@ public class SettingsFragment extends PreferencesListFragment {
 		}
 
 		setPreferenceDefaultValueAndSummary(R.string.pref_voice_mail_key, mPrefs.getVoiceMailUri());
+		setPreferenceDefaultValueAndSummary(R.string.pref_dynamic_photo_uri_key, mPrefs.getDynamicPhotoUri());
 	}
 
 	public void enableDeviceRingtone(boolean enabled) {
@@ -963,6 +964,17 @@ public class SettingsFragment extends PreferencesListFragment {
 				voiceMail.setSummary(newValue.toString());
 				voiceMail.setText(newValue.toString());
 				mPrefs.setVoiceMailUri(newValue.toString());
+				return true;
+			}
+		});
+
+		findPreference(getString(R.string.pref_dynamic_photo_uri_key)).setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+			@Override
+			public boolean onPreferenceChange(Preference preference, Object newValue) {
+				EditTextPreference dynPhotoUri = (EditTextPreference) findPreference(getString(R.string.pref_dynamic_photo_uri_key));
+				dynPhotoUri.setSummary(newValue.toString());
+				dynPhotoUri.setText(newValue.toString());
+				mPrefs.setDynamicPhotoUri(newValue.toString());
 				return true;
 			}
 		});


### PR DESCRIPTION
Add a parameter setting in the Call section (the dynamic photo URI). If a call is made by a contact
who has no photo, an URL query parameter is appended to this URI containing the caller's sip address
and the resulting URI is opened. The resulting bitmap will be displayed in place of the default
avatar image on the incoming call activity.
This allows an external web server to provide caller-specific images, for example, webcam pictures
from door communication systems.
