### PR TITLE
Use getAdbExe() to retrieve adb path.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ android.applicationVariants.all { variant ->
 
 task runApplication() {
   def result = exec {
-    executable = 'adb'
+    executable = android.getAdbExe().toString()
     ignoreExitValue true
     args = ['shell', 'monkey', '-p', getPackageName(), '-c', 'android.intent.category.LAUNCHER', '1']
   }


### PR DESCRIPTION
This will prevent adb related issues such as the one below when the adb executable is not found in the path. Additionally, this is a more consistent approach.
 ```sh
a problem occurred starting process 'command 'adb''
``` 

This will also fix #65 