### PR TITLE
Solved issue of image not picked from Photo's App

### DIFF
--- a/src/android/org/linphone/ChatFragment.java
+++ b/src/android/org/linphone/ChatFragment.java
@@ -798,6 +798,26 @@ public class ChatFragment extends Fragment implements OnClickListener, LinphoneC
 		if (chatRoom != null && path != null && path.length() > 0 && isNetworkReachable) {
 			try {
 				Bitmap bm = BitmapFactory.decodeFile(path);
+				
+				if (bm == null && path.contains("NONE")) {
+                    			Uri uri = Uri.parse(path);
+                    			InputStream is = null;
+                    			if (uri.getAuthority() != null) {
+						try {
+					    		is = getActivity().getContentResolver().openInputStream(uri);
+					    		bm = BitmapFactory.decodeStream(is);
+						} catch (FileNotFoundException e) {
+					    		e.printStackTrace();
+						} finally {
+					    		try {
+								is.close();
+					    		} catch (IOException e) {
+								e.printStackTrace();
+					    		}
+						}
+				    	}
+				}
+				
 				if (bm != null) {
 					FileUploadPrepareTask task = new FileUploadPrepareTask(getActivity(), path, imageSize);
 					task.execute(bm);


### PR DESCRIPTION
If we select image from Google's Photos app. It wasn't getting selected due to invalid image path error. Thus it was returning null Bitmap, which is solved in this patch.