### PR TITLE
Fix battery drain caused by every 10 min wake up

### DIFF
--- a/src/android/org/linphone/LinphoneService.java
+++ b/src/android/org/linphone/LinphoneService.java
@@ -452,11 +452,13 @@ public final class LinphoneService extends Service {
 			}, 5000);
 		}
 
-		//make sure the application will at least wakes up every 10 mn
-		Intent intent = new Intent(this, KeepAliveReceiver.class);
-		PendingIntent keepAlivePendingIntent = PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_ONE_SHOT);
-		AlarmManager alarmManager = ((AlarmManager) this.getSystemService(Context.ALARM_SERVICE));
-		Compatibility.scheduleAlarm(alarmManager, AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + 600000, keepAlivePendingIntent);
+		//make sure the application will at least wakes up every 10 mn when background mode is enabled.
+		if (LinphonePreferences.instance().isBackgroundModeEnabled()) {
+			Intent intent = new Intent(this, KeepAliveReceiver.class);
+			PendingIntent keepAlivePendingIntent = PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_ONE_SHOT);
+			AlarmManager alarmManager = ((AlarmManager) this.getSystemService(Context.ALARM_SERVICE));
+			Compatibility.scheduleAlarm(alarmManager, AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + 600000, keepAlivePendingIntent);
+		}
 
 		mWindowManager = (WindowManager) getSystemService(WINDOW_SERVICE);
 	}


### PR DESCRIPTION
As described at below link, Linphone drains battery because it wakes up
every 10 min.
Periodic wake up should occur only when the backgroud mode is enabled to
receive an incoming call.

https://play.google.com/store/apps/details?id=org.linphone&reviewId=Z3A6QU9xcFRPR05nNTNVRXdhYXNtUXVQU25XYU1HSHN2NEVfQlpsUW1jUmxDWTNEQjdTUDRQTUlBdy1zc1kxRUtWcUlkSWxVd1h3ZVdObEZGdXhBRnFYY2c