### PR TITLE
Declare the support libraries that are needed to compile.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ allprojects {
 
 apply plugin: 'com.android.application'
 
+ext.supportLibVersion = "26.0.1"
+
 dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:+') {
         exclude module: 'support-annotations'
@@ -48,9 +50,26 @@ dependencies {
         compile 'com.google.firebase:firebase-messaging:11.+'
     } else {
         compile fileTree(include: 'gcm.jar', dir: 'libs')
-        compile 'com.android.support:support-v4:26.0.1'
+    }
+    compile 'com.google.firebase:firebase-iid:11.+'
+    compile "com.android.support:support-compat:$supportLibVersion"
+    compile "com.android.support:support-core-ui:$supportLibVersion"
+    compile "com.android.support:support-core-utils:$supportLibVersion"
+    compile "com.android.support:support-annotations:$supportLibVersion"
+}
+
+configurations.all {
+    resolutionStrategy {
+       eachDependency { details ->
+           if (details.requested.group == 'com.android.support') {
+               if (details.requested.name != 'multidex' && details.requested.name != 'multidex-instrumentation') {
+                    details.useVersion "$supportLibVersion"
+               }
+           }
+       }
     }
 }
+
 
 if (firebaseEnable()) {
     apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
Also make sure we use the same version of all support libraries: that other dependencies (like firebase) which may transitively bring in support lib dependencies don't use conflicting versions.

We need to include the firebase-iid dependency even if firebase isn't enabled, because some `LinphoneManager.java` uses `FirebaseInstanceId`.