### PR TITLE
Add preference to control vibration on incoming calls

### DIFF
--- a/res/values/non_localizable_strings.xml
+++ b/res/values/non_localizable_strings.xml
@@ -213,6 +213,7 @@
 
 	<string name="pref_use_lime_encryption_key">pref_use_lime_encryption_key</string>
 	<string name="pref_device_ringtone_key">pref_device_ringtone_key</string>
+	<string name="pref_vibrate_key">pref_vibrate_key</string>
 	<string name="pref_auto_answer_key">pref_auto_answer_key</string>
 	<string name="pref_android_app_settings_key">pref_android_app_settings_key</string>
 	<string name="pref_turn_username_key">pref_turn_username_key</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -353,6 +353,7 @@
     <!-- Call settings -->
     <string name="pref_call_title">Call</string>
     <string name="pref_device_ringtone">Use device ringtone</string>
+    <string name="pref_vibrate">Vibrate on incoming calls</string>
     <string name="pref_auto_answer">Auto answer incoming calls</string>
     <string name="pref_auto_answer_time">Auto answer time(in milliseconds)</string>
     <string name="pref_rfc2833_dtmf">Send in-band DTMFs(RFC2833)</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -188,6 +188,11 @@
 				    android:key="@string/pref_device_ringtone_key"
 					android:persistent="false"/>
 
+				<CheckBoxPreference
+					android:title="@string/pref_vibrate"
+				    android:key="@string/pref_vibrate_key"
+					android:persistent="false"/>
+
 				<ListPreference
 				    android:title="@string/pref_media_encryption"
 					android:key="@string/pref_media_encryption_key"

--- a/src/android/org/linphone/LinphoneManager.java
+++ b/src/android/org/linphone/LinphoneManager.java
@@ -1576,7 +1576,7 @@ public class LinphoneManager implements LinphoneCoreListener, LinphoneChatMessag
 		mAudioManager.setMode(MODE_RINGTONE);
 
 		try {
-			if ((mAudioManager.getRingerMode() == AudioManager.RINGER_MODE_VIBRATE || mAudioManager.getRingerMode() == AudioManager.RINGER_MODE_NORMAL) && mVibrator != null) {
+			if ((mAudioManager.getRingerMode() == AudioManager.RINGER_MODE_VIBRATE || mAudioManager.getRingerMode() == AudioManager.RINGER_MODE_NORMAL) && mVibrator != null && mPrefs.isVibrateEnabled()) {
 				long[] patern = {0,1000,1000};
 				mVibrator.vibrate(patern, 1);
 			}

--- a/src/android/org/linphone/LinphonePreferences.java
+++ b/src/android/org/linphone/LinphonePreferences.java
@@ -1525,6 +1525,14 @@ public class LinphonePreferences {
 		getConfig().setBool("app", "device_ringtone", enable);
 	}
 
+	public boolean isVibrateEnabled() {
+		return getConfig().getBool("app", "vibrate", true);
+	}
+
+	public void enableVibrate(boolean enable) {
+		getConfig().setBool("app", "vibrate", enable);
+	}
+
 	public boolean isBisFeatureEnabled() {
 		return getConfig().getBool("app", "bis_feature", true);
 	}

--- a/src/android/org/linphone/SettingsFragment.java
+++ b/src/android/org/linphone/SettingsFragment.java
@@ -908,6 +908,7 @@ public class SettingsFragment extends PreferencesListFragment {
 
 	private void initCallSettings() {
 		CheckBoxPreference deviceRingtone = (CheckBoxPreference) findPreference(getString(R.string.pref_device_ringtone_key));
+		CheckBoxPreference vibrate = (CheckBoxPreference) findPreference(getString(R.string.pref_vibrate_key));
 		CheckBoxPreference autoAnswer = (CheckBoxPreference) findPreference(getString(R.string.pref_auto_answer_key));
 		CheckBoxPreference rfc2833 = (CheckBoxPreference) findPreference(getString(R.string.pref_rfc2833_dtmf_key));
 		CheckBoxPreference sipInfo = (CheckBoxPreference) findPreference(getString(R.string.pref_sipinfo_dtmf_key));
@@ -919,6 +920,7 @@ public class SettingsFragment extends PreferencesListFragment {
 		rfc2833.setChecked(mPrefs.useRfc2833Dtmfs());
 		sipInfo.setChecked(mPrefs.useSipInfoDtmfs());
 		deviceRingtone.setChecked(mPrefs.isDeviceRingtoneEnabled());
+		vibrate.setChecked(mPrefs.isVibrateEnabled());
 		autoAnswer.setChecked(mPrefs.isAutoAnswerEnabled());
 		incTimeout.setText(String.valueOf(mPrefs.getIncTimeout()));
 		incTimeout.setSummary(String.valueOf(mPrefs.getIncTimeout()));
@@ -958,6 +960,15 @@ public class SettingsFragment extends PreferencesListFragment {
 					LinphoneManager.getInstance().enableDeviceRingtone(false);
 				}
 
+				return true;
+			}
+		});
+
+		findPreference(getString(R.string.pref_vibrate_key)).setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+			@Override
+			public boolean onPreferenceChange(Preference preference, Object newValue) {
+				boolean use = (Boolean) newValue;
+				mPrefs.enableVibrate(use);
 				return true;
 			}
 		});


### PR DESCRIPTION
This PR adds a setting to enable/disable vibration on incoming calls. The app still respects the global system settings as much as it can (see #213 for the discussion on that), I wasn't able to add any of the non-English translations for the setting name, but everything else seems to be working well.

I'm happy to sign a contributor agreement if there is interest in merging this.

Fixes #213