### PR TITLE
Move initialization of BluetoothManager to LinphoneService.

### DIFF
--- a/src/android/org/linphone/LinphoneService.java
+++ b/src/android/org/linphone/LinphoneService.java
@@ -58,6 +58,7 @@ import org.linphone.core.ProxyConfig;
 import org.linphone.core.RegistrationState;
 import org.linphone.mediastream.Log;
 import org.linphone.mediastream.Version;
+import org.linphone.receivers.BluetoothManager;
 import org.linphone.receivers.KeepAliveReceiver;
 import org.linphone.ui.LinphoneOverlay;
 
@@ -430,6 +431,11 @@ public final class LinphoneService extends Service {
         PendingIntent keepAlivePendingIntent = PendingIntent.getBroadcast(this, 0, keepAliveIntent, PendingIntent.FLAG_ONE_SHOT);
         AlarmManager alarmManager = ((AlarmManager) this.getSystemService(Context.ALARM_SERVICE));
         Compatibility.scheduleAlarm(alarmManager, AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + 600000, keepAlivePendingIntent);
+
+        // We need LinphoneService to start bluetoothManager
+        if (Version.sdkAboveOrEqual(Version.API11_HONEYCOMB_30)) {
+            BluetoothManager.getInstance().initBluetooth();
+        }
 
         return START_REDELIVER_INTENT;
     }

--- a/src/android/org/linphone/activities/LinphoneLauncherActivity.java
+++ b/src/android/org/linphone/activities/LinphoneLauncherActivity.java
@@ -36,7 +36,6 @@ import org.linphone.assistant.RemoteProvisioningActivity;
 import org.linphone.call.CallActivity;
 import org.linphone.contacts.ContactsManager;
 import org.linphone.mediastream.Version;
-import org.linphone.receivers.BluetoothManager;
 
 import static android.content.Intent.ACTION_MAIN;
 
@@ -113,11 +112,6 @@ public class LinphoneLauncherActivity extends Activity {
             classToStart = RemoteProvisioningActivity.class;
         } else {
             classToStart = LinphoneActivity.class;
-        }
-
-        // We need LinphoneService to start bluetoothManager
-        if (Version.sdkAboveOrEqual(Version.API11_HONEYCOMB_30)) {
-            BluetoothManager.getInstance().initBluetooth();
         }
 
         mHandler.postDelayed(new Runnable() {


### PR DESCRIPTION
This pull request allows Bluetooth headsets to be used  with Linphone when it is automatically run as service.

Previously, Bluetooth headsets could only be used in Linphone when it was started manually in the foreground.

This was due of the initialization flow in LinphoneLauncherActivity, when launching Linphone in the background,  LinphoneService is not yet ready, so onServiceReady() is not called, thus BluetoothManager is never registered.
