### PR TITLE
Fix app crash if vcard support is not enabled

### DIFF
--- a/app/src/main/java/org/linphone/contacts/LinphoneContact.java
+++ b/app/src/main/java/org/linphone/contacts/LinphoneContact.java
@@ -353,7 +353,7 @@ public class LinphoneContact extends AndroidContact
                 mFriend.getVcard().setFamilyName(mLastName);
                 mFriend.getVcard().setGivenName(mFirstName);
             }
-            if (mOrganization != null) {
+            if ((mOrganization != null) && (mFriend.getVcard() != null)) {
                 mFriend.getVcard().setOrganization(mOrganization);
             }
 


### PR DESCRIPTION
java.lang.NullPointerException: Attempt to invoke interface method 'void org.linphone.core.Vcard.setOrganization(java.lang.String)' on a null object reference
        at org.linphone.contacts.LinphoneContact.createOrUpdateFriend(LinphoneContact.java:358)
        at org.linphone.contacts.LinphoneContact.createOrUpdateFriendFromNativeContact(LinphoneContact.java:410)
        at org.linphone.contacts.AsyncContactsLoader.onPostExecute(AsyncContactsLoader.java:254)
        at org.linphone.contacts.AsyncContactsLoader.onPostExecute(AsyncContactsLoader.java:44)
        at android.os.AsyncTask.finish(AsyncTask.java:695)