### PR TITLE
Add Memory Leak detection for debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,6 +166,9 @@ dependencies {
     }
 
     implementation 'org.linphone:linphone-sdk-android:4.5+'
+
+    // Memory leak detection.
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.4'
 }
 
 if (firebaseEnabled()) {


### PR DESCRIPTION
Add latest Leak Canary to app's debug build.
I've been testing it out myself and currently I'm seeing a few leaks while changing tabs on the bottom navigation handling. 
This change only affects debug builds, hopefully this makes us catch these issues sooner and help us fix them early as well.