### PR TITLE
Pedro/logging wrapper

### DIFF
--- a/app/src/main/java/org/linphone/activities/main/chat/fragments/DetailChatRoomFragment.kt
+++ b/app/src/main/java/org/linphone/activities/main/chat/fragments/DetailChatRoomFragment.kt
@@ -57,7 +57,7 @@ import org.linphone.databinding.ChatRoomDetailFragmentBinding
 import org.linphone.utils.*
 import org.linphone.utils.Event
 
-class DetailChatRoomFragment : MasterFragment<ChatRoomDetailFragmentBinding, ChatMessagesListAdapter>() {
+class DetailChatRoomFragment : MasterFragment<ChatRoomDetailFragmentBinding, ChatMessagesListAdapter>(), LoggingWrapper {
     private lateinit var viewModel: ChatRoomViewModel
     private lateinit var chatSendingViewModel: ChatMessageSendingViewModel
     private lateinit var listViewModel: ChatMessagesListViewModel
@@ -522,7 +522,7 @@ class DetailChatRoomFragment : MasterFragment<ChatRoomDetailFragmentBinding, Cha
         try {
             startActivity(intent)
         } catch (anfe: ActivityNotFoundException) {
-            Log.e("[Chat Message] Couldn't find an activity to handle MIME type: $type")
+            logError("[Chat Message] Couldn't find an activity to handle MIME type: $type", anfe)
 
             val dialogViewModel = DialogViewModel(getString(R.string.dialog_try_open_file_as_text_body), getString(R.string.dialog_try_open_file_as_text_title))
             val dialog = DialogUtils.getDialog(requireContext(), dialogViewModel)
@@ -537,7 +537,7 @@ class DetailChatRoomFragment : MasterFragment<ChatRoomDetailFragmentBinding, Cha
                 try {
                     startActivity(intent)
                 } catch (anfe: ActivityNotFoundException) {
-                    Log.e("[Chat Message] Couldn't find an activity to handle text/plain MIME type")
+                    logError("[Chat Message] Couldn't find an activity to handle text/plain MIME type", anfe)
                     val activity = requireActivity() as MainActivity
                     activity.showSnackBar(R.string.chat_room_cant_open_file_no_app_found)
                 }

--- a/app/src/main/java/org/linphone/core/CoreContext.kt
+++ b/app/src/main/java/org/linphone/core/CoreContext.kt
@@ -45,11 +45,10 @@ import org.linphone.contact.ContactsManager
 import org.linphone.core.tools.Log
 import org.linphone.mediastream.Version
 import org.linphone.notifications.NotificationsManager
-import org.linphone.utils.AppUtils
+import org.linphone.utils.*
 import org.linphone.utils.Event
-import org.linphone.utils.LinphoneUtils
 
-class CoreContext(val context: Context, coreConfig: Config) {
+class CoreContext(val context: Context, coreConfig: Config): LoggingWrapper {
     var stopped = false
     val core: Core
     val handler: Handler = Handler(Looper.getMainLooper())
@@ -305,7 +304,7 @@ class CoreContext(val context: Context, coreConfig: Config) {
         val f = File(userCertsPath)
         if (!f.exists()) {
             if (!f.mkdir()) {
-                Log.e("[Context] $userCertsPath can't be created.")
+                logError("[Context] $userCertsPath can't be created.")
             }
         }
         core.userCertificatesPath = userCertsPath
@@ -357,7 +356,7 @@ class CoreContext(val context: Context, coreConfig: Config) {
     fun transferCallTo(addressToCall: String) {
         val currentCall = core.currentCall ?: core.calls.first()
         if (currentCall == null) {
-            Log.e("[Context] Couldn't find a call to transfer")
+            logError("[Context] Couldn't find a call to transfer")
         } else {
             Log.i("[Context] Transferring current call to $addressToCall")
             currentCall.transfer(addressToCall)
@@ -377,7 +376,7 @@ class CoreContext(val context: Context, coreConfig: Config) {
 
         val address: Address? = core.interpretUrl(stringAddress)
         if (address == null) {
-            Log.e("[Context] Failed to parse $stringAddress, abort outgoing call")
+            logError("[Context] Failed to parse $stringAddress, abort outgoing call")
             callErrorMessageResourceId.value = Event(R.string.call_error_network_unreachable)
             return
         }
@@ -387,7 +386,7 @@ class CoreContext(val context: Context, coreConfig: Config) {
 
     fun startCall(address: Address, forceZRTP: Boolean = false) {
         if (!core.isNetworkReachable) {
-            Log.e("[Context] Network unreachable, abort outgoing call")
+            logError("[Context] Network unreachable, abort outgoing call")
             callErrorMessageResourceId.value = Event(R.string.call_error_network_unreachable)
             return
         }
@@ -397,7 +396,7 @@ class CoreContext(val context: Context, coreConfig: Config) {
             params?.mediaEncryption = MediaEncryption.ZRTP
         }
         if (LinphoneUtils.checkIfNetworkHasLowBandwidth(context)) {
-            Log.w("[Context] Enabling low bandwidth mode!")
+            logWarn("[Context] Enabling low bandwidth mode!")
             params?.enableLowBandwidth(true)
         }
         params?.recordFile = LinphoneUtils.getRecordingFilePathForAddress(address)
@@ -427,7 +426,7 @@ class CoreContext(val context: Context, coreConfig: Config) {
         } else {
             val call = core.currentCall
             if (call == null) {
-                Log.w("[Context] Switching camera while not in call")
+                logWarn("[Context] Switching camera while not in call")
                 return
             }
             call.update(null)
@@ -545,6 +544,6 @@ class CoreContext(val context: Context, coreConfig: Config) {
                 return
             }
         }
-        Log.w("[Context] Didn't find any bluetooth audio device, keeping default audio route")
+        logWarn("[Context] Didn't find any bluetooth audio device, keeping default audio route")
     }
 }

--- a/app/src/main/java/org/linphone/utils/LoggingWrapper.kt
+++ b/app/src/main/java/org/linphone/utils/LoggingWrapper.kt
@@ -1,0 +1,47 @@
+package org.linphone.utils
+
+
+import android.os.Build
+import android.util.Log
+
+/**
+ * This Logger class serves as a wrapper that clients can use to further customize how their logs are
+ * collected and optionally plug-in logging frameworks such as Firebase, etc.
+ */
+interface LoggingWrapper {
+
+    val loggerTag: String
+        get() {
+            val tag = javaClass.simpleName
+
+            // Before API 24 there was a limit on the tag length for logcat.
+            return if (tag.length <= MAX_TAG_LENGTH || Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                tag
+            } else {
+                tag.substring(0, MAX_TAG_LENGTH)
+            }
+        }
+}
+
+class DefaultLoggingWrapper : LoggingWrapper
+
+private const val MAX_TAG_LENGTH = 23
+
+
+fun LoggingWrapper.logWarn(message: String, thr: Throwable? = null) {
+    val logMessage = if (thr != null) {
+        message + ". E.: ${thr.message}"
+    } else {
+        message
+    }
+    Log.w(this.loggerTag, logMessage)
+}
+
+fun LoggingWrapper.logError(message: String, thr: Throwable? = null) {
+    val logMessage = if (thr != null) {
+        message + ". E.: ${thr.message}"
+    } else {
+        message
+    }
+    Log.e(this.loggerTag, logMessage)
+}

--- a/app/src/main/java/org/linphone/utils/LoggingWrapper.kt
+++ b/app/src/main/java/org/linphone/utils/LoggingWrapper.kt
@@ -34,6 +34,7 @@ fun LoggingWrapper.logWarn(message: String, thr: Throwable? = null) {
     } else {
         message
     }
+    org.linphone.core.tools.Log.w(logMessage)
     Log.w(this.loggerTag, logMessage)
 }
 
@@ -43,5 +44,6 @@ fun LoggingWrapper.logError(message: String, thr: Throwable? = null) {
     } else {
         message
     }
+    org.linphone.core.tools.Log.e(logMessage)
     Log.e(this.loggerTag, logMessage)
 }


### PR DESCRIPTION
The main idea with this change is to allow clients to capture the logs in their own fashion. Motivated by the need to capture relevant error Logs to accompany Firebase crashes reports.

This is just a POC for initial discussion - the complete solution would be to replace all android-app side calls to the SDK's Log class with this wrapper class instead. I realize that this solution will NOT include the logs that are written at the SDK level itself - however when using a framework such as Firebase one can NO longer run a custom code on crash as it will interfere with Firebase crash report itself. That should probably be written on the header of the Class as a caveat. 

Additionally, this logging wrapper and the codebase being Kotlin one can easily capture the calling class without explicit naming which can further enrich the log data at no cost to the development time and copy-paste proof ✌🏻 