### PR TITLE
Correctly setting call state to active on an outgoing call, …

### DIFF
--- a/app/src/main/java/org/linphone/telecom/TelecomConnectionService.kt
+++ b/app/src/main/java/org/linphone/telecom/TelecomConnectionService.kt
@@ -22,6 +22,7 @@ package org.linphone.telecom
 import android.content.ComponentName
 import android.content.Intent
 import android.net.Uri
+import android.os.Handler
 import android.telecom.*
 import org.linphone.LinphoneApplication.Companion.coreContext
 import org.linphone.core.Call
@@ -37,20 +38,8 @@ class TelecomConnectionService : ConnectionService() {
             state: Call.State?,
             message: String
         ) {
-            Log.i("[Telecom Connection Service] call [${call.callLog.callId}] state changed: $state")
-            when (call.state) {
-                Call.State.OutgoingProgress -> {
-                    for (connection in TelecomHelper.get().connections) {
-                        if (connection.callId.isEmpty()) {
-                            Log.i("[Telecom Connection Service] Updating connection with call ID: ${call.callLog.callId}")
-                            connection.callId = core.currentCall?.callLog?.callId ?: ""
-                        }
-                    }
-                }
-                Call.State.Error -> onCallError(call)
-                Call.State.End, Call.State.Released -> onCallEnded(call)
-                Call.State.Connected -> onCallConnected(call)
-            }
+            Log.i("[Telecom Connection Service] onCallStateChanged from listener")
+            onCallStateChanged(call, state, core)
         }
 
         override fun onLastCallEnded(core: Core) {
@@ -66,11 +55,31 @@ class TelecomConnectionService : ConnectionService() {
         }
     }
 
-    override fun onCreate() {
-        super.onCreate()
+    private fun onCallStateChanged(
+        call: Call?,
+        state: Call.State?,
+        core: Core
+    ) {
+        Log.i("[Telecom Connection Service] call [${call?.callLog?.callId}] state changed: $state")
+        when (call?.state) {
+            Call.State.OutgoingProgress -> {
+                for (connection in TelecomHelper.get().connections) {
+                    if (connection.callId.isEmpty()) {
+                        Log.i("[Telecom Connection Service] Updating connection with call ID: ${call.callLog.callId}")
+                        connection.callId = core.currentCall?.callLog?.callId ?: ""
+                    }
+                }
+            }
+            Call.State.Error -> onCallError(call)
+            Call.State.End, Call.State.Released -> onCallEnded(call)
+            Call.State.StreamsRunning -> onCallConnected(call)
+        }
+    }
 
-        Log.i("[Telecom Connection Service] onCreate()")
+    override fun onCreate() {
         coreContext.core.addListener(listener)
+        super.onCreate()
+        Log.i("[Telecom Connection Service] onCreate()")
     }
 
     override fun onUnbind(intent: Intent?): Boolean {
@@ -109,7 +118,9 @@ class TelecomConnectionService : ConnectionService() {
             }
 
             val connection = NativeCallWrapper(callId)
-            connection.setDialing()
+            if (connection.state != Connection.STATE_ACTIVE) {
+                connection.setDialing()
+            }
 
             val providedHandle = request.address
             connection.setAddress(providedHandle, TelecomManager.PRESENTATION_ALLOWED)
@@ -117,6 +128,14 @@ class TelecomConnectionService : ConnectionService() {
             Log.i("[Telecom Connection Service] Address is $providedHandle")
 
             TelecomHelper.get().connections.add(connection)
+            // CLB: Added setting the call state changed from creating, because the call can be directly accepted, and the state wouldn't be set correctly.
+            Handler().postDelayed(
+                {
+                    Log.i("[Telecom Connection Service] onCallStateChanged delayed")
+                    onCallStateChanged(coreContext.core.currentCall, coreContext.core.currentCall?.state, coreContext.core)
+                },
+                100
+            )
             connection
         } else {
             Log.e("[Telecom Connection Service] Error: $accountHandle $componentName")
@@ -206,7 +225,23 @@ class TelecomConnectionService : ConnectionService() {
         val callId = call.callLog.callId
         val connection = TelecomHelper.get().findConnectionForCallId(callId.orEmpty())
         if (connection == null) {
-            Log.e("[Telecom Connection Service] Failed to find connection for call id: $callId")
+            Log.e("[Telecom Connection Service] Retrying failed to find connection for call id: $callId")
+            // CLB: Added post delayed to try again if at first the connection wasn't found.
+            Handler().postDelayed(
+                {
+                    val connection = TelecomHelper.get().findConnectionForCallId(callId.orEmpty())
+                    if (connection == null) {
+                        Log.e("[Telecom Connection Service] Failed to find connection for call id: $callId")
+                        return@postDelayed
+                    }
+                    Log.i("[Telecom Connection Service] found connection for call id delayed: $callId")
+
+                    if (connection.state != Connection.STATE_HOLDING) {
+                        connection.setActive()
+                    }
+                },
+                500
+            )
             return
         }
 


### PR DESCRIPTION
…when at first failed, the call is later tried again. And on start of the outgoing call the call state changed is also called.
Should fix this: [https://github.com/BelledonneCommunications/linphone-android/issues/1648](url)