### PR TITLE
Hide Android IME when automatically showing the dial pad

### DIFF
--- a/app/src/main/java/org/linphone/ui/main/history/fragment/StartCallFragment.kt
+++ b/app/src/main/java/org/linphone/ui/main/history/fragment/StartCallFragment.kt
@@ -209,7 +209,13 @@ class StartCallFragment : GenericAddressPickerFragment() {
         super.onResume()
 
         if (corePreferences.automaticallyShowDialpad) {
-            viewModel.isNumpadVisible.value = true
+            coreContext.postOnMainThread {
+                binding.searchBar.hideKeyboard()
+                binding.searchBar.clearFocus()
+                coreContext.postOnCoreThread {
+                    viewModel.isNumpadVisible.postValue(true)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
When automatically show dialpad is active, ex. with this setting:

```
[ui]
automatically_show_dialpad=1
```

and activity is resumed with android IME shown before, the dialpad will be shown automatically, but the android IME is also visible.
This behaviour is inconsistent from a user perpective.

This PR hides the Android IME on resume when `automatically_show_dialpad=1`.