### PR TITLE
Support dialing with hw numpad keys

### DIFF
--- a/app/src/main/java/org/linphone/ui/call/CallActivity.kt
+++ b/app/src/main/java/org/linphone/ui/call/CallActivity.kt
@@ -66,6 +66,9 @@ import org.linphone.ui.call.viewmodel.CallsViewModel
 import org.linphone.ui.call.viewmodel.CurrentCallViewModel
 import org.linphone.ui.call.viewmodel.SharedCallViewModel
 import org.linphone.ui.main.MainActivity
+import android.view.KeyEvent
+import androidx.navigation.fragment.NavHostFragment
+import org.linphone.ui.call.fragment.ActiveCallFragment
 
 @UiThread
 class CallActivity : GenericActivity() {
@@ -406,6 +409,28 @@ class CallActivity : GenericActivity() {
                 }
             }
         }
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        // search active fragment in call_nav_container
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.call_nav_container) as? NavHostFragment
+
+        val activeCallFragment = navHostFragment
+            ?.childFragmentManager
+            ?.fragments
+            ?.filterIsInstance<ActiveCallFragment>()
+            ?.firstOrNull { it.isVisible }
+
+        if (activeCallFragment != null) {
+            // forward keys to ActiveCallFragment, which has the chance to consume it
+            if (activeCallFragment.handleHardwareDialpadKeyEvent(event)) {
+                return true // event consumed
+            }
+        }
+
+        // forward not consumed keys
+        return super.dispatchKeyEvent(event)
     }
 
     @UiThread

--- a/app/src/main/java/org/linphone/ui/main/MainActivity.kt
+++ b/app/src/main/java/org/linphone/ui/main/MainActivity.kt
@@ -77,6 +77,9 @@ import org.linphone.utils.Event
 import org.linphone.utils.FileUtils
 import org.linphone.utils.LinphoneUtils
 import androidx.core.content.edit
+import androidx.navigation.fragment.NavHostFragment
+import org.linphone.ui.main.history.fragment.StartCallFragment
+import android.view.KeyEvent
 
 @UiThread
 class MainActivity : GenericActivity() {
@@ -436,6 +439,27 @@ class MainActivity : GenericActivity() {
         super.onNewIntent(intent)
         Log.d("$TAG Handling new intent")
         handleIntent(intent)
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        // check if StartCallFragment is visible
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.main_nav_container) as? NavHostFragment
+        val startCallFragment = navHostFragment
+            ?.childFragmentManager
+            ?.fragments
+            ?.filterIsInstance<StartCallFragment>()
+            ?.firstOrNull { it.isVisible }
+
+        if (startCallFragment != null) {
+            // StartCallFragment is visible, forward keys to it, so it can decide to consume it
+            if (startCallFragment.handleHardwareDialpadKeyEvent(event)) {
+                return true // event consumed
+            }
+        }
+
+        // otherwise return false if no other object consumes it
+        return super.dispatchKeyEvent(event)
     }
 
     @SuppressLint("RtlHardcoded")


### PR DESCRIPTION
Combined with #2494 and with this setting:

```
[ui]
automatically_show_dialpad=1
```

The user can do basic calls with an hardware keyboard.

This also fixes an show/hide dialpad inconsistency, where the android IME and dialpad is shown at the same time when used in combination with #2494, or android IME is not hidden and dialpad is not shown automatically.

Basically it just hides the android IME before showing the dialpad with an delay and in the right threads.

To reproduce the first behaviour you have to use #2494, to reproduce the second one, do the following:
- Set `automatically_show_dialpad=1`
- open linphone, goto new call and press search field to open android IME
- Press home button on phone/tablet
- press recent button on phone/tablet
- select linphone
- Android IME will be shown

This replaces #2494