### PR TITLE
Fix: Route REGISTER requests through Outbound Proxy if enabled

### DIFF
--- a/app/src/main/java/org/linphone/ui/assistant/viewmodel/ThirdPartySipAccountLoginViewModel.kt
+++ b/app/src/main/java/org/linphone/ui/assistant/viewmodel/ThirdPartySipAccountLoginViewModel.kt
@@ -239,43 +239,33 @@ class ThirdPartySipAccountLoginViewModel
             accountParams.identityAddress = identityAddress
 
             val proxyServerValue = proxy.value.orEmpty().trim()
-            val proxyServerAddress = if (proxyServerValue.isNotEmpty()) {
-                val server = if (proxyServerValue.startsWith("sip:")) {
-                    proxyServerValue
+            val outboundProxyValue = outboundProxy.value.orEmpty().trim()
+            
+            val targetServerValue = if (outboundProxyValue.isNotEmpty()) outboundProxyValue else proxyServerValue
+
+            val targetServerAddress = if (targetServerValue.isNotEmpty()) {
+                val server = if (targetServerValue.startsWith("sip:")) {
+                    targetServerValue
                 } else {
-                    "sip:$proxyServerValue"
+                    "sip:$targetServerValue"
                 }
                 Factory.instance().createAddress(server)
             } else {
                 domainAddress ?: Factory.instance().createAddress("sip:$domainWithoutSip")
             }
-            proxyServerAddress?.transport = when (transport.value.orEmpty().trim()) {
+
+            targetServerAddress?.transport = when (transport.value.orEmpty().trim()) {
                 TransportType.Tcp.name.uppercase(Locale.getDefault()) -> TransportType.Tcp
                 TransportType.Tls.name.uppercase(Locale.getDefault()) -> TransportType.Tls
                 else -> TransportType.Udp
             }
-            Log.i("$TAG Created proxy server SIP address [${proxyServerAddress?.asStringUriOnly()}]")
-            accountParams.serverAddress = proxyServerAddress
 
-            val outboundProxyValue = outboundProxy.value.orEmpty().trim()
-            val outboundProxyAddress = if (outboundProxyValue.isNotEmpty()) {
-                val server = if (outboundProxyValue.startsWith("sip:")) {
-                    outboundProxyValue
-                } else {
-                    "sip:$outboundProxyValue"
-                }
-                Factory.instance().createAddress(server)
-            } else {
-                null
-            }
-            if (outboundProxyAddress != null) {
-                outboundProxyAddress.transport = when (transport.value.orEmpty().trim()) {
-                    TransportType.Tcp.name.uppercase(Locale.getDefault()) -> TransportType.Tcp
-                    TransportType.Tls.name.uppercase(Locale.getDefault()) -> TransportType.Tls
-                    else -> TransportType.Udp
-                }
-                Log.i("$TAG Created outbound proxy server SIP address [${outboundProxyAddress?.asStringUriOnly()}]")
-                accountParams.setRoutesAddresses(arrayOf(outboundProxyAddress))
+            Log.i("$TAG Custom Route: Forcing server address to [${targetServerAddress?.asStringUriOnly()}]")
+            
+            accountParams.serverAddress = targetServerAddress
+            
+            if (outboundProxyValue.isNotEmpty() && targetServerAddress != null){
+                accountParams.setRoutesAddresses(arrayOf(targetServerAddress))
             }
 
             val prefix = internationalPrefix.value.orEmpty().trim()


### PR DESCRIPTION
### Description
This PR fixes an issue in the `ThirdPartySipAccountLoginViewModel` where the "Outbound Proxy" configuration was parsed but completely ignored for the actual `REGISTER` transaction. 

Previously, the outbound proxy address was only passed to `accountParams.setRoutesAddresses()`, which correctly routes `INVITE` requests but leaves the `serverAddress` pointing to the main SIP domain. As a result, the app attempted to send the `REGISTER` directly to the internal domain IP, failing for users behind restrictive NATs (like mobile CGNAT) who rely on an external SBC/Proxy to reach their PBX.

### Changes made
* Evaluated the `outboundProxy` field. If populated, it now overrides the target proxy server value.
* Forced `accountParams.serverAddress` to use the `targetServerAddress` (which resolves to the Outbound Proxy if provided) so the `REGISTER` request follows the correct physical path.
* Maintained the `setRoutesAddresses()` logic for subsequent transactions (calls).

### Testing
Tested on a physical Android device over a mobile network (4G/5G) using TCP transport. The app successfully bypasses the carrier's CGNAT by sending the `REGISTER` directly to the Outbound Proxy's public IP, while keeping the internal IP as the SIP domain identity.

Closes #2560